### PR TITLE
update to require digest/md5 instead of md5

### DIFF
--- a/s3sync.rb
+++ b/s3sync.rb
@@ -20,7 +20,7 @@ module S3sync
   require 'getoptlong'
   #require 'generator' # http://www.ruby-doc.org/stdlib/libdoc/generator/rdoc/classes/Generator.html
   require 'thread_generator' # memory doesn't leak with this one, at least nothing near as bad
-  require 'md5'
+  require 'digest/md5'
   require 'tempfile'
   require 's3try'
    


### PR DESCRIPTION
s3sync didn't work for me giving error of:
`
home/sroot/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in require': cannot load such file -- md5 (LoadError)
`

It appears ruby 1.9 uses digest/md5 instead of md5
I suggest someone more knowledgeable checks this before accepting the pull request.
